### PR TITLE
Add aria-label for arrow button when using link in submenu

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The `<ilw-header-menu-section>` may have a `right` attribute. This will right-al
 ## Code Examples
 
 ```html
-<ilw-header-menu>
+<ilw-header-menu slot="navigation">
     <ul>
         <li><ilw-header-menu-section>
             <span slot="label">Start Here</span>

--- a/src/HeaderMenuSection.ts
+++ b/src/HeaderMenuSection.ts
@@ -215,7 +215,7 @@ export default class HeaderMenuSection extends LitElement {
         var withLink = html`
             <div class="header-link ${this.mouseover ? "highlighted" : ""} ${this.compact ? "compact" : ""} ${this.current ? "current" : ""}" @mouseover="${this.toggleMouseOver.bind(this)}"  @mouseout="${this.toggleMouseOver.bind(this)}">
                 <slot name="link"></slot>
-                <button class="arrow-only" @click=${this.handleToggleClick.bind(this)} aria-expanded=${this.expanded ? 'true' : 'false'} aria-controls="items">
+                <button class="arrow-only" @click=${this.handleToggleClick.bind(this)} aria-expanded=${this.expanded ? 'true' : 'false'} aria-label=${this.querySelector('a[slot="link"]')?.textContent + ' submenu'} aria-controls="items">
                     ${this.renderArrow()}
                 </button>
             </div>


### PR DESCRIPTION
Attempt at addressing https://github.com/web-illinois/ilw-header-menu/issues/15 