### PR TITLE
V1.3.1, #31, #10

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ You can put a `<ilw-header-menu-section>` inside another. This allows you to nes
 
 The `<ilw-header-menu-section>` may have a `right` attribute. This will right-align the menu so it doesn't float off the right-hand side of the page. 
 
+### current attribute
+
+The `<ilw-header-menu-section>` may have a `current` attribute. This will mark the header menu section as being where the user is in the menu navigation structure. 
+
 ## Code Examples
 
 ```html

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@illinois-toolkit/ilw-header-menu",
-    "version": "1.0.3",
+    "version": "1.3.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@illinois-toolkit/ilw-header-menu",
-            "version": "1.0.3",
+            "version": "1.3.1",
             "license": "MIT",
             "dependencies": {
                 "lit": "3.1.3"
@@ -1677,6 +1677,7 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
             "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -1715,6 +1716,7 @@
             "integrity": "sha512-EK5cY7Q1D8JNhSaPKVK4pwBFvaTmZxEnoKXLG/U9gmdDcihQGNzFlgIvaxezFR4glP1LsuiedwMBqCXH3wZccA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "esbuild": "^0.21.3",
                 "postcss": "^8.4.43",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "repository": "github:web-illinois/ilw-header-menu",
     "private": false,
     "license": "MIT",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "type": "module",
     "files": [
         "src/**",

--- a/samples/index.html
+++ b/samples/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Header Menu Component</title>
     <link rel="stylesheet" href="https://cdn.brand.illinois.edu/illinois.css">
-    <link rel="stylesheet" href="https://dev.toolkit.illinois.edu/ilw-global/3.0.0-alpha/ilw-global.css">
+    <link rel="stylesheet" href="https://cdn.toolkit.illinois.edu/ilw-global/3/ilw-global.css">
     <script type="module" src="/src/ilw-header-menu.ts"></script>
     <script>
         document.addEventListener("DOMContentLoaded", function(event) {
@@ -158,6 +158,7 @@
                 <li><a href="#">Porphyry</a></li>
               </ul>
             </ilw-header-menu-section></li>
+        <li><a href="/components_toc/index.html">Components</a></li>
           </ul>
       </ilw-header-menu-section></li>
       <li><a href="/demo/index.html" id="current3">Demo Pages</a></li>

--- a/samples/index.html
+++ b/samples/index.html
@@ -24,7 +24,7 @@
 <body style="margin: 0; padding: 0;">
 <ilw-header-menu>
     <ul>
-        <li><ilw-header-menu-section id="current1">
+        <li><ilw-header-menu-section id="current1" current>
             <span slot="label">Start Here</span>
             <ul>
             <li><a href="/getting_started/index.html">Getting Started</a></li>
@@ -32,10 +32,10 @@
             <li><a href="/upgrade/index.html">Upgrade from V2</a></li>
             </ul>
         </ilw-header-menu-section></li>
-        <li><ilw-header-menu-section id="current2" linked="true">
+        <li><ilw-header-menu-section id="current2" linked="true" current>
             <a slot="link" href="/philosophy/index.html">Information</a>
             <ul>
-              <li><a href="/philosophy/index.html">Philosophy</a></li>
+              <li><a href="/philosophy/index.html" aria-current="page">Philosophy</a></li>
               <li><a href="/links/index.html">Helpful Links</a></li>
               <li><a href="/github/index.html">Organization and Github</a></li>
               <li> <ilw-header-menu-section>
@@ -111,7 +111,7 @@
           </ul>
       </ilw-header-menu-section></li>
       <li><ilw-header-menu-section id="current4" linked="true">
-          <a slot="link" href="/philosophy/index.html">Testing Links</a>
+          <a slot="link" aria-current="page" href="/philosophy/index.html">Testing Links</a>
           <ul>
             <li><ilw-header-menu-section linked="true">
               <a slot="link" href="#">Garnet</a>

--- a/samples/index.html
+++ b/samples/index.html
@@ -24,7 +24,7 @@
 <body style="margin: 0; padding: 0;">
 <ilw-header-menu>
     <ul>
-        <li><ilw-header-menu-section id="current1" current>
+        <li><ilw-header-menu-section id="current1">
             <span slot="label">Start Here</span>
             <ul>
             <li><a href="/getting_started/index.html">Getting Started</a></li>
@@ -44,6 +44,15 @@
                   <li><a href="#">Amphibole</a></li>
                   <li><a href="#">Pyroxene</a></li>
                   <li><a href="#">Feldspar</a></li>
+                </ul>
+              </ilw-header-menu-section></li>
+              <li><ilw-header-menu-section linked="true">
+                <a slot="link" href="#">Garnet</a>
+                <ul>
+                  <li><a href="#">Gneiss</a></li>
+                  <li><a href="#">Peridotite</a></li>
+                  <li><a href="#">Syenite</a></li>
+                  <li><a href="#">Porphyry</a></li>
                 </ul>
               </ilw-header-menu-section></li>
               <li><ilw-header-menu-section linked="true">
@@ -111,7 +120,7 @@
           </ul>
       </ilw-header-menu-section></li>
       <li><ilw-header-menu-section id="current4" linked="true">
-          <a slot="link" aria-current="page" href="/philosophy/index.html">Testing Links</a>
+          <a slot="link" href="/philosophy/index.html">Testing Links</a>
           <ul>
             <li><ilw-header-menu-section linked="true">
               <a slot="link" href="#">Garnet</a>

--- a/src/HeaderMenu.styles.css
+++ b/src/HeaderMenu.styles.css
@@ -5,8 +5,8 @@
       --ilw-header-menu--link-color--hover: var(--il-altgeld);
       --ilw-header-menu--link-background: transparent;
       --ilw-header-menu--link-background--hover: white;
-      --ilw-header-menu--link-background--focus: var(--il-industrial-lighter-4);
-      --ilw-header-menu--link-background--sub--focus: var(--il-industrial-lighter-4);
+      --ilw-header-menu--link-background--focus: var(--ilw-color--focus--background);
+      --ilw-header-menu--link-background--sub--focus: var(--ilw-color--focus--background);
       --ilw-header-menu--link-border-bottom-highlight: 4px solid transparent;
       --ilw-header-menu--link-border-bottom-highlight--hover: 4px solid var(--il-orange);
       --ilw-header-menu--link-border-bottom-highlight--focus: 4px solid var(--il-blue);

--- a/src/HeaderMenu.styles.css
+++ b/src/HeaderMenu.styles.css
@@ -13,6 +13,7 @@
       --ilw-header-menu--link-border-left-highlight: none;
       --ilw-header-menu--link-border-left-highlight--focus: none;
       --ilw-header-menu--background: #E8E9EB;
+      --ilw-header-menu--background-menu-expanded: #FFFFFF;
       --ilw-header-menu--flex-direction: row;
       --ilw-header-menu--items--position: absolute;
       --ilw-header-menu--items--border: 1px solid rgb(0, 0, 0, .01);

--- a/src/HeaderMenu.ts
+++ b/src/HeaderMenu.ts
@@ -1,6 +1,7 @@
 import { LitElement, html, unsafeCSS, CSSResultGroup } from "lit";
 // @ts-ignore
 import styles from './HeaderMenu.styles.css?inline';
+// @ts-ignore
 import './HeaderMenu.css';
 import { customElement, property } from "lit/decorators.js";
 import HeaderMenuSection from "./HeaderMenuSection";

--- a/src/HeaderMenuSection.css
+++ b/src/HeaderMenuSection.css
@@ -33,7 +33,7 @@ ilw-header-menu-section[linked] a[slot="link"] {
    }
 }
 
-ilw-header-menu-section[linked][aria-current="page"] a[slot="link"] {
+ilw-header-menu-section[linked] a[slot="link"][aria-current="page"], ilw-header-menu-section[linked][current] a[slot="link"] {
     border-color: var(--il-blue);
 
     &:hover {
@@ -84,6 +84,9 @@ ilw-header-menu-section {
                 border-bottom: var(--ilw-header-menu--link-border-bottom-highlight);
 
 
+                &[aria-current] {
+                      border-left: var(--ilw-header-menu--link-border-left-highlight--focus);
+                }
                 &:hover {
                     background: var(--ilw-header-menu--link-background--hover);
                     border-bottom: var(--ilw-header-menu--link-border-bottom-highlight--hover);

--- a/src/HeaderMenuSection.css
+++ b/src/HeaderMenuSection.css
@@ -31,9 +31,13 @@ ilw-header-menu-section[linked] a[slot="link"] {
      border-left: var(--ilw-header-menu--link-border-left-highlight--focus);
      border-bottom: var(--ilw-header-menu--link-border-bottom-highlight--focus);
    }
+
+    &:hover:focus {
+        color: var(--il-blue);
+    }
 }
 
-ilw-header-menu-section[linked] a[slot="link"][aria-current="page"], ilw-header-menu-section[linked][current] a[slot="link"] {
+ilw-header-menu-section[linked] a[slot="link"][aria-current="page"], ilw-header-menu-section[linked][current] > a[slot="link"] {
     border-color: var(--il-blue);
 
     &:hover {
@@ -99,6 +103,10 @@ ilw-header-menu-section {
                   background: var(--ilw-header-menu--link-background--sub--focus);
                   border-bottom: var(--ilw-header-menu--link-border-bottom-highlight--focus);
                   border-left: var(--ilw-header-menu--link-border-left-highlight--focus);
+                }
+
+                &:hover:focus {
+                    color: var(--il-blue);
                 }
             }
         }

--- a/src/HeaderMenuSection.styles.css
+++ b/src/HeaderMenuSection.styles.css
@@ -14,7 +14,7 @@
   left: var(--ilw-header-menu--items--left);
   top: var(--ilw-header-menu--items--top);
   z-index: 100;
-  background: white;
+  background: var(--ilw-header-menu--background-menu-expanded);
 }
 
 #items.expanded.right {

--- a/src/HeaderMenuSection.styles.css
+++ b/src/HeaderMenuSection.styles.css
@@ -74,6 +74,11 @@ button, .link {
       border-bottom: var(--ilw-header-menu--link-border-bottom-highlight--focus);
       border-left: var(--ilw-header-menu--link-border-left-highlight--focus);
     }
+
+    &:focus:hover {
+      color: var(--il-blue);
+      fill: var(--il-blue);
+    }
 }
 
 button[aria-expanded="true"] { 

--- a/src/HeaderMenuSection.ts
+++ b/src/HeaderMenuSection.ts
@@ -1,6 +1,7 @@
 import { LitElement, html, unsafeCSS } from "lit";
 // @ts-ignore
 import styles from './HeaderMenuSection.styles.css?inline';
+// @ts-ignore
 import './HeaderMenuSection.css';
 import { customElement, property } from "lit/decorators.js";
 
@@ -50,6 +51,7 @@ export default class HeaderMenuSection extends LitElement {
     connectedCallback() {
         super.connectedCallback();
     }
+    
 
     handleToggleClick(evt: Event) {
         this.expanded = !this.expanded;
@@ -209,6 +211,17 @@ export default class HeaderMenuSection extends LitElement {
     }
 
 
+    handleFocusout(target: FocusEvent) {
+        const currentTarget = target.target as HTMLElement;
+        const htmlTarget = target.relatedTarget as HTMLElement;
+        const slot = this.renderRoot.querySelector('slot:not([name])') as HTMLSlotElement;
+        var elements = slot?.assignedElements({flatten: true});
+        if (currentTarget?.tagName == 'A' && !Array.from(elements[0].children).includes(htmlTarget.parentElement as Element)) {
+            this.expanded = false;
+        }
+        target.stopPropagation();
+    }
+
     render() {
         let isSubMenu = this.parentElement != null && this.parentElement.closest("ilw-header-menu-section") != null;
         this.current = this.current || (this.getAttribute('aria-current') != null && (this.getAttribute('aria-current') === 'page' || this.getAttribute('aria-current') === 'true'));
@@ -231,7 +244,7 @@ export default class HeaderMenuSection extends LitElement {
         `;
 
         return html`
-            <div class="${isSubMenu ? 'submenu' : 'menu'} parent" @ilw-header-menu-section-expanded=${this.handleNavigationSectionToggleClick}>
+            <div @focusout="${this.handleFocusout}" class="${isSubMenu ? 'submenu' : 'menu'} parent" @ilw-header-menu-section-expanded=${this.handleNavigationSectionToggleClick}>
                 ${this.linked ? withLink : withoutLink}
                 <div id="items" class="${this.expanded ? 'expanded' : ''} ${this.right ? 'right' : ''}">
                     <slot></slot>


### PR DESCRIPTION
This pull request introduces a new `current` attribute for the `<ilw-header-menu-section>` component to better indicate the user's current location in the navigation. It also improves keyboard accessibility and focus handling, updates styles for better visual feedback, and makes small documentation and sample updates.

**New Feature: Current Attribute**
- Added support for a `current` attribute on `<ilw-header-menu-section>`, allowing sections to be marked as the user's current location in the navigation. This includes updated documentation and sample usage. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R30-R33) [[2]](diffhunk://#diff-d6a470ab5db859e24840afbf68e874ffbcf2b632ff4b12587329016046139390L35-R38)

**Accessibility and Keyboard Navigation**
- Implemented a `handleFocusout` method in `HeaderMenuSection.ts` to collapse expanded menus when focus moves outside, improving keyboard navigation and accessibility. [[1]](diffhunk://#diff-05f27ab59f7fdf33ab1bfc262ea99bb685a79e8cdd874b67db0add3e2714b3c8R214-R224) [[2]](diffhunk://#diff-05f27ab59f7fdf33ab1bfc262ea99bb685a79e8cdd874b67db0add3e2714b3c8L234-R247)

**Styling and Visual Feedback**
- Updated CSS to use a new background variable for expanded menus and improved focus/hover color handling for links, especially when marked as current. [[1]](diffhunk://#diff-d907b6cacd58c80817f8b66f2f265de29080f307224829c525ac769313cfd8eaL8-R16) [[2]](diffhunk://#diff-00e54f71d722a849f7693f3532b96fb4d973f471cb55af8887b691c4a4e50862L17-R17) [[3]](diffhunk://#diff-00e54f71d722a849f7693f3532b96fb4d973f471cb55af8887b691c4a4e50862R77-R81) [[4]](diffhunk://#diff-38102ce70b6e931e63b46fa7bf56487caa48124e259fd7db836a0f4b09632fe4R34-R40) [[5]](diffhunk://#diff-38102ce70b6e931e63b46fa7bf56487caa48124e259fd7db836a0f4b09632fe4R91-R93) [[6]](diffhunk://#diff-38102ce70b6e931e63b46fa7bf56487caa48124e259fd7db836a0f4b09632fe4R107-R110)
- Enhanced styling so that links with `aria-current` or the `current` attribute receive appropriate focus and border highlights. [[1]](diffhunk://#diff-38102ce70b6e931e63b46fa7bf56487caa48124e259fd7db836a0f4b09632fe4R34-R40) [[2]](diffhunk://#diff-38102ce70b6e931e63b46fa7bf56487caa48124e259fd7db836a0f4b09632fe4R91-R93)

**Documentation and Sample Updates**
- Updated `README.md` to document the new `current` attribute.
- Updated `samples/index.html` to demonstrate the new attribute and improved navigation structure, and switched to the production global CSS CDN. [[1]](diffhunk://#diff-d6a470ab5db859e24840afbf68e874ffbcf2b632ff4b12587329016046139390L9-R9) [[2]](diffhunk://#diff-d6a470ab5db859e24840afbf68e874ffbcf2b632ff4b12587329016046139390L35-R38) [[3]](diffhunk://#diff-d6a470ab5db859e24840afbf68e874ffbcf2b632ff4b12587329016046139390R58-R66) [[4]](diffhunk://#diff-d6a470ab5db859e24840afbf68e874ffbcf2b632ff4b12587329016046139390R170)

**Maintenance**
- Bumped the package version to `1.3.1` in `package.json`.
- Ensured both main and section CSS files are imported in the relevant TypeScript files. [[1]](diffhunk://#diff-4d846398825ca9a4f396ddd50d6b2b6819ce32498afd0466fd7eb5d532d780cdR4) [[2]](diffhunk://#diff-05f27ab59f7fdf33ab1bfc262ea99bb685a79e8cdd874b67db0add3e2714b3c8R4)